### PR TITLE
Caching agent plugin updates to support combine Cache task

### DIFF
--- a/src/Agent.Plugins/PipelineCache/PipelineCachePluginConstants.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCachePluginConstants.cs
@@ -4,7 +4,6 @@ namespace Agent.Plugins.PipelineCache
 {
     public static class PipelineCachePluginConstants
     {
-        public static readonly Guid SaveCacheTaskId = new Guid("F2333FED-1017-4A2F-AAC6-02A185279E1E");
-        public static readonly Guid RestoreCacheTaskId = new Guid("D53CCAB4-555E-4494-9D06-11DB043FB4A9");
+        public static readonly Guid CacheTaskId = new Guid("1B7B4CD4-D9AA-4165-8C00-1BBC91B196B5");
     }
 }

--- a/src/Agent.Plugins/PipelineCache/PipelineCachePluginConstants.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCachePluginConstants.cs
@@ -4,6 +4,6 @@ namespace Agent.Plugins.PipelineCache
 {
     public static class PipelineCachePluginConstants
     {
-        public static readonly Guid CacheTaskId = new Guid("1B7B4CD4-D9AA-4165-8C00-1BBC91B196B5");
+        public static readonly Guid CacheTaskId = new Guid("D53CCAB4-555E-4494-9D06-11DB043FB4A9");
     }
 }

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheServer.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheServer.cs
@@ -136,9 +136,13 @@ namespace Agent.Plugins.PipelineCache
                     
                     if (!string.IsNullOrEmpty(variableToSetOnHit))
                     {
+                        if (context.Variables.ContainsKey(variableToSetOnHit))
+                        {
+                            context.Output($"Overwriting the 'variableToSetOnHit' value to {variableToSetOnHit}");
+                        }
                         context.SetVariable($"{variableToSetOnHit}", "True");
                     }
-                    Console.WriteLine("Cache restored.");
+                    context.Output("Cache restored.");
                 }
             }
         }

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheServer.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheServer.cs
@@ -136,9 +136,9 @@ namespace Agent.Plugins.PipelineCache
                     
                     if (!string.IsNullOrEmpty(variableToSetOnHit))
                     {
-                        if (context.Variables.ContainsKey(variableToSetOnHit))
+                        if(context.Variables.ContainsKey(variableToSetOnHit))
                         {
-                            context.Output($"Overwriting the 'variableToSetOnHit' value to {variableToSetOnHit}");
+                            context.Output($"Overwriting cacheHitVar variable to {variableToSetOnHit}");
                         }
                         context.SetVariable($"{variableToSetOnHit}", "True");
                     }

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheServer.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheServer.cs
@@ -136,7 +136,7 @@ namespace Agent.Plugins.PipelineCache
                     
                     if (!string.IsNullOrEmpty(variableToSetOnHit))
                     {
-                        context.SetVariable($"{PipelineArtifactConstants.PipelineCache}.{variableToSetOnHit}", "True");
+                        context.SetVariable($"{variableToSetOnHit}", "True");
                     }
                     Console.WriteLine("Cache restored.");
                 }

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
@@ -18,9 +18,9 @@ namespace Agent.Plugins.PipelineCache
 {
     public abstract class PipelineCacheTaskPluginBase : IAgentTaskPlugin
     {
-        public abstract Guid Id { get; }
+        public Guid Id => PipelineCachePluginConstants.CacheTaskId;
 
-        public string Stage => "main";
+        public abstract String Stage { get; }
 
         public async Task RunAsync(AgentTaskPluginExecutionContext context, CancellationToken token)
         {

--- a/src/Agent.Plugins/PipelineCache/RestorePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/RestorePipelineCacheV0.cs
@@ -20,7 +20,7 @@ namespace Agent.Plugins.PipelineCache
 {    
     public class RestorePipelineCacheV0 : PipelineCacheTaskPluginBase
     {
-        public override Guid Id => PipelineCachePluginConstants.RestoreCacheTaskId;
+        public override string Stage => "main";
 
         protected override async Task ProcessCommandInternalAsync(
             AgentTaskPluginExecutionContext context, 

--- a/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
@@ -29,6 +29,14 @@ namespace Agent.Plugins.PipelineCache
             string salt,
             CancellationToken token)
         {
+            var JobStatus = context.Variables["agent.jobstatus"];
+
+            if(JobStatus != null && !JobStatus.Value.Equals("Succeeded"))
+            {
+                context.Output($"Exiting because the JobStatus is {JobStatus.Value}");
+                return;
+            }
+
             string[] key = keyStr.Split(
                 new[] { '\n' },
                 StringSplitOptions.RemoveEmptyEntries

--- a/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
@@ -29,8 +29,12 @@ namespace Agent.Plugins.PipelineCache
             string salt,
             CancellationToken token)
         {
-            var JobStatus = context.Variables["agent.jobstatus"];
+            if(!context.Variables.ContainsKey("agent.jobstatus"))
+            {
+                return;
+            }
 
+            var JobStatus = context.Variables["agent.jobstatus"];
             if(JobStatus != null && !JobStatus.Value.Equals("Succeeded"))
             {
                 context.Output($"Exiting because the JobStatus is {JobStatus.Value}");

--- a/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
@@ -20,7 +20,7 @@ namespace Agent.Plugins.PipelineCache
 {    
     public class SavePipelineCacheV0 : PipelineCacheTaskPluginBase
     {
-        public override Guid Id => PipelineCachePluginConstants.SaveCacheTaskId;
+        public override string Stage => "post";
 
         protected override async Task ProcessCommandInternalAsync(
             AgentTaskPluginExecutionContext context, 


### PR DESCRIPTION
Update the agent plugins responsible for Pipeline Caching restore and save to work with the new combined Cache task. This task performs restore in the main execution phase of the task and save in the post execution phase. From a user perspective, this means developers only need to add and configure one task (Cache) instead of both RestoreCache and SaveCache